### PR TITLE
Fix canonicalize_fails_if_subpath_is_file on MacOS

### DIFF
--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -317,8 +317,13 @@ impl Registry {
                 // final component must exist
                 self.get(&sane_path)?;
             } else {
-                // non-final component must be a directory
+                // non-final component must be a directory, unless we're on macos,
+                // which insists only that the partial path exist
+                #[cfg(not(target_os = "macos"))]
                 self.get_dir(&sane_path)?;
+                
+                #[cfg(target_os = "macos")]
+                self.get(&sane_path)?;
             }
         }
         Ok(sane_path)

--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -319,11 +319,11 @@ impl Registry {
             } else {
                 // non-final component must be a directory, unless we're on macos,
                 // which insists only that the partial path exist
-                #[cfg(not(target_os = "macos"))]
-                self.get_dir(&sane_path)?;
-                
-                #[cfg(target_os = "macos")]
-                self.get(&sane_path)?;
+                if cfg!(target_os = "macos") {
+                    self.get(&sane_path)?;
+                } else {
+                    self.get_dir(&sane_path)?;
+                }
             }
         }
         Ok(sane_path)

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -203,7 +203,12 @@ macro_rules! test_fs {
             make_test!(canonicalize_ok_with_dotdot_if_paths_exist, $fs);
             make_test!(canonicalize_fails_with_dotdot_if_path_doesnt_exist, $fs);
             make_test!(canonicalize_cant_go_lower_than_root, $fs);
+
+            #[cfg(not(target_os = "macos"))]
             make_test!(canonicalize_fails_if_subpath_is_file, $fs);
+
+            #[cfg(target_os = "macos")]
+            make_test!(canonicalize_ok_if_subpath_is_file, $fs);
 
             #[cfg(unix)]
             make_test!(mode_returns_permissions, $fs);
@@ -2048,6 +2053,7 @@ fn canonicalize_cant_go_lower_than_root<T: FileSystem>(fs: &T, parent: &Path) {
     assert_eq!(result.unwrap(), root);
 }
 
+#[cfg(not(target_os = "macos"))]
 fn canonicalize_fails_if_subpath_is_file<T: FileSystem>(fs: &T, parent: &Path) {
     let dir = parent.join("test");
     fs.create_dir(&dir).unwrap();
@@ -2057,6 +2063,22 @@ fn canonicalize_fails_if_subpath_is_file<T: FileSystem>(fs: &T, parent: &Path) {
     let dotdot = parent.join("test/test.txt/../test.txt");
     let result = fs.canonicalize(&dotdot);
     assert!(result.is_err());
+}
+
+#[cfg(target_os = "macos")]
+fn canonicalize_ok_if_subpath_is_file<T: FileSystem>(fs: &T, parent: &Path) {
+    let dir = parent.join("test");
+    fs.create_dir(&dir).unwrap();
+    let path = dir.join("test.txt");
+    write_file(fs, &path, "content 3").unwrap();
+
+    let dotdot = parent.join("test/test.txt/../test.txt");
+    let result = fs.canonicalize(&dotdot);
+    assert!(result.is_ok());
+
+    let content = read_file(fs, result.unwrap().as_path());
+    assert_eq!(content.unwrap(), b"content 3");
+
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
canonicalize_fails_if_subpath_is_file

specifically contradicts MacOS behavior.  MacOS canonicalizes a path successfully even if one of the non-final sub-paths is a file.

Limiting the test to non-macos platforms, and adding a new test for macos which verifies that the path _does_ canonicalize.