### PR TITLE
Fix canonicalize_ok_if_relative_path and canonicalize_ok_if_path_ends_in_dotdot on MacOS

### DIFF
--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1994,7 +1994,7 @@ fn canonicalize_ok_if_relative_path<T: FileSystem>(fs: &T, parent: &Path) {
     fs.set_current_dir(&parent).unwrap();
     let result = fs.canonicalize(&PathBuf::from("."));
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), parent);
+    assert_eq!(result.unwrap(), fs.canonicalize(parent).unwrap());
 
     fs.set_current_dir(save_current_dir).unwrap();
 }
@@ -2006,7 +2006,7 @@ fn canonicalize_ok_if_path_ends_in_dotdot<T: FileSystem>(fs: &T, parent: &Path) 
     let dotdot = dir.join("..");
     let result = fs.canonicalize(&dotdot);
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), parent);
+    assert_eq!(result.unwrap(), fs.canonicalize(parent).unwrap());
 }
 
 fn canonicalize_fails_if_file_doesnt_exist<T: FileSystem>(fs: &T, parent: &Path) {


### PR DESCRIPTION
canonicalize_ok_if_relative_path
canonicalize_ok_if_path_ends_in_dotdot

...both do something like this:

A = current working directory
B = A with redirection
assert(canonicalize(B) == A)

What if A is not already canonical? I think the place Mac OS puts its temp directories has a symlink in the path, and that's why these tests fail on mac. I propose fixing by adding an extra call to canonicalize in the check, so it looks more like this:

A = current working directory
B = A with redirection
assert(canonicalize(B) == canonicalize(A))