### PR TITLE
Fix canonicalize_ok_if_file_exists on MacOS

### DIFF
--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1961,10 +1961,12 @@ fn writable_object_extends_file<T: FileSystem>(fs: &T, parent: &Path) {
 
 fn canonicalize_ok_if_file_exists<T: FileSystem>(fs: &T, parent: &Path) {
     let path = parent.join("test.txt");
-    write_file(fs, &path, "test.txt").unwrap();
+    write_file(fs, &path, "contents 1").unwrap();
     let result = fs.canonicalize(&path);
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), path);
+    let result_path = result.unwrap();
+    let contents = read_file(fs, &result_path).unwrap();
+    assert_eq!(contents, b"contents 1");
 }
 
 fn canonicalize_ok_if_root<T: FileSystem>(fs: &T, _parent: &Path) {


### PR DESCRIPTION
os::canonicalize_ok_if_file_exists

works by writing a file at a path A, canonicalizing A and then checking that the canonicalized path A is equal to A.  This assumes that the path to A is canonical in the first place, which it might not be if the temp directory the test is running isn't canonical.

Proposed fix: instead of comparing paths, compare file contents.