### PR TITLE
Fix remove_file_fails_if_node_is_a_directory on MacOS

### DIFF
--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -147,10 +147,13 @@ impl Registry {
     pub fn remove_file(&mut self, path: &Path) -> Result<()> {
         match self.get_file(path) {
             Ok(_) => self.remove(path).and(Ok(())),
-            Err(e) => Err(if cfg!(target_os = "macos") {
-                create_error(ErrorKind::PermissionDenied)
+            Err(err) => Err(if cfg!(target_os = "macos") {
+                match err.kind() {
+                    ErrorKind::Other => create_error(ErrorKind::PermissionDenied),
+                    _ => err,
+                }
             } else {
-                e
+                err
             }),
         }
     }

--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -145,16 +145,14 @@ impl Registry {
     }
 
     pub fn remove_file(&mut self, path: &Path) -> Result<()> {
+        if cfg!(target_os = "macos") && self.is_dir(path) {
+            // on MacOS, attempting to delete a directory results
+            // in a "permission denied" error.
+            return Err(create_error(ErrorKind::PermissionDenied));
+        }
         match self.get_file(path) {
             Ok(_) => self.remove(path).and(Ok(())),
-            Err(err) => Err(if cfg!(target_os = "macos") {
-                match err.kind() {
-                    ErrorKind::Other => create_error(ErrorKind::PermissionDenied),
-                    _ => err,
-                }
-            } else {
-                err
-            }),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -239,7 +239,13 @@ impl Registry {
     pub fn get_file(&self, path: &Path) -> Result<&File> {
         self.get(path).and_then(|node| match node {
             Node::File(ref file) => Ok(file),
-            Node::Dir(_) => Err(create_error(ErrorKind::Other)),
+            Node::Dir(_) => {
+                if cfg!(target_os = "macos") {
+                    Err(create_error(ErrorKind::PermissionDenied))
+                } else {
+                    Err(create_error(ErrorKind::Other))
+                }
+            }
         })
     }
 

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -909,7 +909,14 @@ fn remove_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path
     let result = fs.remove_file(&path);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Other);
+
+    let error_kind = result.unwrap_err().kind();
+
+    if cfg!(target_os = "macos") {
+        assert!(error_kind == ErrorKind::PermissionDenied);
+    } else {
+        assert!(error_kind == ErrorKind::Other);
+    }
 }
 
 fn copy_file_copies_a_file<T: FileSystem>(fs: &T, parent: &Path) {

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -921,11 +921,13 @@ fn remove_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path
 
     let error_kind = result.unwrap_err().kind();
 
-    assert!(error_kind == if cfg!(target_os = "macos") {
+    let expected_error_kind = if cfg!(target_os = "macos") {
         ErrorKind::PermissionDenied
     } else {
         ErrorKind::Other
-    });
+    };
+
+    assert!(error_kind == expected_error_kind);
 }
 
 fn copy_file_copies_a_file<T: FileSystem>(fs: &T, parent: &Path) {

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -912,11 +912,11 @@ fn remove_file_fails_if_node_is_a_directory<T: FileSystem>(fs: &T, parent: &Path
 
     let error_kind = result.unwrap_err().kind();
 
-    if cfg!(target_os = "macos") {
-        assert!(error_kind == ErrorKind::PermissionDenied);
+    assert!(error_kind == if cfg!(target_os = "macos") {
+        ErrorKind::PermissionDenied
     } else {
-        assert!(error_kind == ErrorKind::Other);
-    }
+        ErrorKind::Other
+    });
 }
 
 fn copy_file_copies_a_file<T: FileSystem>(fs: &T, parent: &Path) {


### PR DESCRIPTION
This test

os::remove_file_fails_if_node_is_a_directory

fails because MacOS produces a different error from other platforms when attempting to remove_file a directory.  MacOS returns PermissionDenied, where other OS's return Other.

Modifying fake-filessystem to produce PermissionDenied when running on MacOS, and changing the test to reflect.