### PR TITLE
Canonicalize temp dirs created for tests

### DIFF
--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -10,8 +10,12 @@ macro_rules! make_test {
         fn $test() {
             let fs = $fs();
             let temp_dir = fs.temp_dir("test").unwrap();
+            // some OSes create temp dirs which are not canonical.
+            // make them canonical to prevent some tests from
+            // failing.
+            let temp_dir = fs.canonicalize(temp_dir.path()).unwrap();
 
-            super::$test(&fs, temp_dir.path());
+            super::$test(&fs, &temp_dir);
         }
     };
 }


### PR DESCRIPTION
If I understand correctly, #6 #7 #8 are all related to the fact that some OSes (macos in particular) may create temp dirs that are not canonical?

@2-complex are you able to see if this commit solves these issues in particular?
If so, we can ~~kill~~ save three birds with one stone ?